### PR TITLE
zookeeper mirror link update

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-zookeeper_mirror: http://apache.org/dist/zookeeper
+zookeeper_mirror: http://archive.apache.org/dist/zookeeper
 zookeeper_parent_install_dir: /usr/local
 zookeeper_dl_timeout_seconds: 600
 


### PR DESCRIPTION
zookeeper mirror update
updated apache archive mirror link
older mirror link we are able to access only v3.5.10, 3.6.4, 3.7.1, 3.8.2 (for rest we need to use this archive link)